### PR TITLE
updated boost download URLS

### DIFF
--- a/build-vllm-docker.py
+++ b/build-vllm-docker.py
@@ -332,6 +332,9 @@ class BuildScript:
                 f"  git clone --recursive --single-branch --depth=1 -b {tag} {org}/{repo}.git {subdir};",
                 check_exitcode=True,
             )
+            # Patching https://github.com/triton-inference-server/python_backend/blob/r23.10/CMakeLists.txt
+            # by updating boost_1_79_0.tar.gz source URL
+            self.cmd("sed -i 's|URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz|URL https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz|' /tmp/tritonbuild/python/CMakeLists.txt")
             self.cmd("}" if target_platform() == "windows" else "fi")
 
 
@@ -1075,7 +1078,8 @@ RUN pip3 install --upgrade pip && \
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN wget -O /tmp/boost.tar.gz \
-        https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz && \
+        # Updated boost_1_80_0.tar.gz download URL
+        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \            
     (cd /tmp && tar xzf boost.tar.gz) && \
     mv /tmp/boost_1_80_0/boost /usr/include/boost
 


### PR DESCRIPTION
Issues when building docker images using `build-vllm-docker.py`. Updated broken `https://boostorg.jfrog.io` links with from `https://www.boost.org/releases/1.79.0/`

Need additional testing when serving models with the created image, issues at serving time:

Models failed to load:
`
triton_server_vllm-1  | I0807 23:50:08.061784 8 server.cc:293] Waiting for in-flight requests to complete.
triton_server_vllm-1  | I0807 23:50:08.061789 8 server.cc:309] Timeout 30: Found 0 model versions that have in-flight inferences
triton_server_vllm-1  | I0807 23:50:08.061795 8 server.cc:324] All models are stopped, unloading models
triton_server_vllm-1  | I0807 23:50:08.061799 8 server.cc:331] Timeout 30: Found 0 live models and 0 in-flight non-inference requests
triton_server_vllm-1  | error: creating server: Internal - failed to load all models
triton_server_vllm-1 exited with code 1
`