### PR TITLE
Fix Dockerfile syntax error in build-vllm-docker.py (Follow up to PR #2)

### DIFF
--- a/build-vllm-docker.py
+++ b/build-vllm-docker.py
@@ -1078,8 +1078,7 @@ RUN pip3 install --upgrade pip && \
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN wget -O /tmp/boost.tar.gz \
-        # Updated boost_1_80_0.tar.gz download URL
-        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \            
+    https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \            
     (cd /tmp && tar xzf boost.tar.gz) && \
     mv /tmp/boost_1_80_0/boost /usr/include/boost
 


### PR DESCRIPTION
This PR fixes a build failure introduced in PR #2.

**The Problem:**
In PR #2, a comment line (`# Updated boost...`) was inserted into the middle of a multi-line `RUN` command in the python build script. This breaks the Dockerfile line continuation (`\`), causing Docker to interpret the URL on the next line as an unknown instruction.

**Error Log:**
```text
Dockerfile.buildbase:29
ERROR: failed to build: failed to solve: dockerfile parse error on line 29: unknown instruction: https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz
```

**The Solution:**
I have removed the comment line so that the `RUN wget ...` command continues correctly to the next line.